### PR TITLE
Adding metricRelabelings and relabelings options

### DIFF
--- a/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
+++ b/charts/kafka-lag-exporter/templates/060-ServiceMonitor.yaml
@@ -30,6 +30,14 @@ spec:
     {{- if .Values.prometheus.serviceMonitor.scrapeTimeout }}
     scrapeTimeout: {{ .Values.prometheus.serviceMonitor.scrapeTimeout }}
     {{- end }}
+    {{- with .Values.prometheus.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+    {{- tpl (toYaml . | nindent 6) $ }}
+    {{- end }}
+    {{- with .Values.prometheus.serviceMonitor.relabelings }}
+    relabelings:
+    {{- tpl (toYaml . | nindent 6) $ }}
+    {{- end }}
   {{- if .Values.prometheus.serviceMonitor.additionalConfig }}
 {{ toYaml .Values.prometheus.serviceMonitor.additionalConfig | indent 2}}
   {{- end }}

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -189,6 +189,11 @@ prometheus:
   serviceMonitor:
     enabled: false
     interval: "30s"
+    # metricRelabelings:
+    #  - sourceLabels: [__name__]
+    #    regex: ^(process_|jvm_).*$
+    #    action: drop
+    # relabelings: []
     # service monitor label selectors: https://github.com/helm/charts/blob/f5a751f174263971fafd21eee4e35416d6612a3d/stable/prometheus-operator/templates/prometheus/prometheus.yaml#L74
     # additionalLabels:
     #   prometheus: k8s


### PR DESCRIPTION
Adding support in the Service Monitor object for relabeling.

Prometheus documentation: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config

