### PR TITLE
Adding support for Redis lookup tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,7 +314,6 @@ Redis Details (`kafka-lag-exporter.lookup-table.redis{}`)
 | `timeout`    | `60`                   | No       | Redis connection timeout.                                                                                           |
 | `prefix`     | `"kafka-lag-exporter"` | No       | Prefix used by all the keys.                                                                                        |
 | `separator`  | `":"`                  | No       | Separator used to build the keys.                                                                                   |
-| `resolution` | `"1 minute"`           | No       | Resolution of the lookup table. Last point will get updated if the collection interval is less than the resolution. |
 | `retention`  | `"1 day"`              | No       | Retention of the lookup table. Points will get removed from the table after that.                                   |
 | `expiration` | `"1 day"`              | No       | Expiration (TTL) of all the keys.                                                                                   |
 

--- a/README.md
+++ b/README.md
@@ -200,6 +200,18 @@ helm install kafka-lag-exporter/kafka-lag-exporter \
   --set serviceAccount.create=true
 ```
 
+Install with Redis persistence enabled
+
+```
+helm install kafka-lag-exporter/kafka-lag-exporter \
+  --name kafka-lag-exporter \
+  --namespace myproject \
+  --set redis.enabled=true \
+  --set redis.host=myredisserver \
+  --set clusters\[0\].name=my-cluster \
+  --set clusters\[0\].bootstrapBrokers=my-cluster-kafka-bootstrap.myproject:9092
+```
+
 Run a debug install (`DEBUG` logging, debug helm chart install, force docker pull policy to `Always`).
 
 ```
@@ -270,7 +282,8 @@ General Configuration (`kafka-lag-exporter{}`)
 | `reporters.influxdb.async`    | `true`               | Flag to enable influxdb async **non-blocking** write mode to send metrics      
 | `sinks`                       | `["PrometheusEndpointSink"]` | Specify which reporters must be used to send metrics. Possible values are: `PrometheusEndpointSink`, `InfluxDBPusherSink`, `GraphiteEndpointSink`.  (if not set, only Prometheus is activated)     
 | `poll-interval`               | `30 seconds`         | How often to poll Kafka for latest and group offsets                                                                                  |
-| `lookup-table-size`           | `60`                 | The maximum window size of the look up table **per partition**                                                                        |
+| `lookup-table.memory.size`    | `60`                 | The maximum window size of the in memory look up table **per partition**                                                              |
+| `lookup-table.redis`          | `{}`                 | Configuration for the Redis persistence. This category is optional and will override use of the in memory lookup table if defined     |
 | `client-group-id`             | `kafkalagexporter`   | Consumer group id of kafka-lag-exporter's client connections                                                                          |
 | `kafka-client-timeout`        | `10 seconds`         | Connection timeout when making API calls to Kafka                                                                                     |
 | `clusters`                    | `[]`                 | A statically defined list of Kafka connection details.  This list is optional if you choose to use the Strimzi auto-discovery feature |
@@ -291,6 +304,21 @@ Kafka Cluster Connection Details (`kafka-lag-exporter.clusters[]`)
 | `admin-client-properties` | `{}`        | No       | A map of key value pairs used to configure the `AdminClient`. See the [Admin Config](https://kafka.apache.org/documentation/#adminclientconfigs) section of the Kafka documentation for options.          |
 | `labels`                  | `{}`        | No       | A map of key value pairs will be set as additional custom labels per cluster for all the metrics in prometheus.                                                                                           |
 
+Redis Details (`kafka-lag-exporter.lookup-table.redis{}`)
+
+| Key          | Default                | Required | Description                                                                                                         |
+|--------------|------------------------|----------|---------------------------------------------------------------------------------------------------------------------|
+| `database`   | `0`                    | No       | Redis database number.                                                                                              |
+| `host`       | `"localhost"`          | No       | Redis server to use.                                                                                                |
+| `port`       | `6379`                 | No       | Redis port to use.                                                                                                  |
+| `timeout`    | `60`                   | No       | Redis connection timeout.                                                                                           |
+| `prefix`     | `"kafka-lag-exporter"` | No       | Prefix used by all the keys.                                                                                        |
+| `separator`  | `":"`                  | No       | Separator used to build the keys.                                                                                   |
+| `resolution` | `"1 minute"`           | No       | Resolution of the lookup table. Last point will get updated if the collection interval is less than the resolution. |
+| `retention`  | `"1 day"`              | No       | Retention of the lookup table. Points will get removed from the table after that.                                   |
+| `expiration` | `"1 day"`              | No       | Expiration (TTL) of all the keys.                                                                                   |
+
+
 Watchers (`kafka-lag-exporters.watchers{}`)
 
 | Key                 | Default     | Description                              |
@@ -308,7 +336,7 @@ kafka-lag-exporter {
       port = 9999
     }
   }
-  lookup-table-size = 120
+  lookup-table.memory.size = 120
   clusters = [
     {
       name = "a-cluster"

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ lazy val kafkaLagExporter =
         PrometheusHttpServer,
         ScalaJava8Compat,
         AkkaHttp,
+        ScalaRedis,
         Logback,
         IAMAuthLib,
         ScalaTest,
@@ -52,7 +53,8 @@ lazy val kafkaLagExporter =
         AkkaStreamsTestKit,
         AlpakkaKafkaTestKit,
         TestcontainersKafka,
-        TestcontainersInfluxDb
+        TestcontainersInfluxDb,
+        TestcontainersRedis
       ),
       dockerApiVersion := Some(DockerApiVersion(1, 41)),
       dockerRepository := Option(System.getenv("DOCKER_REPOSITORY"))

--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -9,7 +9,6 @@ data:
     kafka-lag-exporter {
       port = {{ .Values.service.port }}
       poll-interval = {{ .Values.pollIntervalSeconds }} seconds
-      lookup-table-size = {{ .Values.lookupTableSize }}
       client-group-id = "{{ .Values.clientGroupId }}"
       kafka-client-timeout = {{ .Values.kafkaClientTimeoutSeconds }} seconds
       clusters = [
@@ -73,6 +72,41 @@ data:
         }
         {{- end }}
       ]
+      {{- if .Values.lookup.redis.enabled }}
+      lookup-table.redis = {
+        {{- with .Values.lookup.redis.host }}
+        host = {{ . | quote }}
+        {{- end }}
+        {{- with .Values.lookup.redis.database }}
+        database = {{ . | quote }}
+        {{- end }}
+        {{- with .Values.lookup.redis.port }}
+        port = {{ . | quote }}
+        {{- end }}
+        {{- with .Values.lookup.redis.timeout }}
+        timeout = {{ . | quote }}
+        {{- end }}
+        {{- with .Values.lookup.redis.prefix }}
+        prefix = {{ . | quote }}
+        {{- end }}
+        {{- with .Values.lookup.redis.separator }}
+        separator = {{ . | quote }}
+        {{- end }}
+        {{- with .Values.lookup.redis.resolution }}
+        resolution = {{ . | quote }}
+        {{- end }}
+        {{- with .Values.lookup.redis.retention }}
+        retention = {{ . | quote }}
+        {{- end }}
+        {{- with .Values.lookup.redis.expiration }}
+        expiration = {{ . | quote }}
+        {{- end }}
+      }
+      {{- else }}
+      lookup-table.memory = {
+        size = {{ .Values.lookupTableSize | default .Values.lookup.memory.size }}
+      }
+      {{- end }}
 
       {{- $sinks := list -}}
       {{- if .Values.reporters.prometheus.enabled }}

--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -73,35 +73,19 @@ data:
         {{- end }}
       ]
       {{- if .Values.lookup.redis.enabled }}
+      {{- with .Values.lookup.redis }}
       lookup-table.redis = {
-        {{- with .Values.lookup.redis.host }}
-        host = {{ . | quote }}
-        {{- end }}
-        {{- with .Values.lookup.redis.database }}
-        database = {{ . | quote }}
-        {{- end }}
-        {{- with .Values.lookup.redis.port }}
-        port = {{ . | quote }}
-        {{- end }}
-        {{- with .Values.lookup.redis.timeout }}
-        timeout = {{ . | quote }}
-        {{- end }}
-        {{- with .Values.lookup.redis.prefix }}
-        prefix = {{ . | quote }}
-        {{- end }}
-        {{- with .Values.lookup.redis.separator }}
-        separator = {{ . | quote }}
-        {{- end }}
-        {{- with .Values.lookup.redis.resolution }}
-        resolution = {{ . | quote }}
-        {{- end }}
-        {{- with .Values.lookup.redis.retention }}
-        retention = {{ . | quote }}
-        {{- end }}
-        {{- with .Values.lookup.redis.expiration }}
-        expiration = {{ . | quote }}
-        {{- end }}
+        host = {{ .host | quote }}
+        database = {{ .database | quote }}
+        port = {{ .port | quote }}
+        timeout = {{ .timeout }}
+        prefix = {{ .prefix | quote }}
+        separator = {{ .separator | quote }}
+        resolution = {{ .resolution | quote }}
+        retention = {{ .retention | quote }}
+        expiration = {{ .expiration | quote }}
       }
+      {{- end }}
       {{- else }}
       lookup-table.memory = {
         size = {{ .Values.lookupTableSize | default .Values.lookup.memory.size }}

--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -81,7 +81,6 @@ data:
         timeout = {{ .timeout }}
         prefix = {{ .prefix | quote }}
         separator = {{ .separator | quote }}
-        resolution = {{ .resolution | quote }}
         retention = {{ .retention | quote }}
         expiration = {{ .expiration | quote }}
       }

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -30,10 +30,25 @@ clusters: {}
 #      location: ny
 #      zone: "us-east"
 
+# Lookup Table
+lookup:
+  memory:
+    ## Size of the sliding window of offsets to keep in each partition's lookup table
+    size: 60
+  redis:
+    enabled: false
+    # host: localhost
+    # database: 0
+    # port: 6379
+    # timeout: 60
+    # prefix: kafka-lag-exporter
+    # separator: ":"
+    # resolution: 1 minute
+    # retention: 1 day
+    # expiration: 7 days
+
 ## The interval between refreshing metrics
 pollIntervalSeconds: 30
-## Size of the sliding window of offsets to keep in each partition's lookup table
-lookupTableSize: 60
 ## The Consumer Group `group.id` to use when connecting to Kafka
 clientGroupId: "kafkalagexporter"
 ## The timeout when communicating with Kafka clusters

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -43,7 +43,6 @@ lookup:
     # timeout: 60
     # prefix: kafka-lag-exporter
     # separator: ":"
-    # resolution: 1 minute
     # retention: 1 day
     # expiration: 7 days
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,10 @@
 # https://hub.docker.com/r/wurstmeister/zookeeper/
 version: '2'
 services:
+  redis:
+    image: redis:6.2.6
+    ports:
+      - "6379:6379"
   zookeeper:
     image: wurstmeister/zookeeper:3.4.6
     ports:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,6 +8,7 @@ object Version {
   val Kafka = "3.2.2"
   val Testcontainers = "1.17.3"
   val IAMAuth = "1.1.4"
+  val Redis = "3.42"
 }
 
 object Dependencies {
@@ -46,6 +47,7 @@ object Dependencies {
     "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
   val AkkaHttp = "com.typesafe.akka" %% "akka-http" % "10.2.10"
   val IAMAuthLib = "software.amazon.msk" % "aws-msk-iam-auth" % Version.IAMAuth
+  val ScalaRedis = "net.debasishg" %% "redisclient" % Version.Redis
 
   /* Test */
   val AkkaTypedTestKit =
@@ -60,4 +62,6 @@ object Dependencies {
     "org.testcontainers" % "kafka" % Version.Testcontainers % Test
   val TestcontainersInfluxDb =
     "org.testcontainers" % "influxdb" % Version.Testcontainers % Test
+  val TestcontainersRedis =
+    "org.testcontainers" % "spock" % Version.Testcontainers % Test
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,20 +1,28 @@
 kafka-lag-exporter {
   reporters.prometheus.port = 8000
-  reporters.prometheus.port = ${?KAFKA_LAG_EXPORTER_PORT}
   poll-interval = 30 seconds
-  poll-interval = ${?KAFKA_LAG_EXPORTER_POLL_INTERVAL_SECONDS}
-  lookup-table-size = 60
-  lookup-table-size = ${?KAFKA_LAG_EXPORTER_LOOKUP_TABLE_SIZE}
-  client-group-id = "kafkalagexporter"
-  client-group-id = ${?KAFKA_LAG_EXPORTER_CLIENT_GROUP_ID}
-  kafka-client-timeout = 10 seconds
-  kafka-client-timeout = ${?KAFKA_LAG_EXPORTER_KAFKA_CLIENT_TIMEOUT_SECONDS}
-  clusters = []
-  clusters = ${?KAFKA_LAG_EXPORTER_CLUSTERS}
-  watchers = {
-    strimzi = "false"
-    strimzi = ${?KAFKA_LAG_EXPORTER_STRIMZI}
+  # Deprecated
+  lookup-table-size = ${kafka-lag-exporter.lookup-table.memory.size}
+  lookup-table = {
+    memory = {
+      size = 60
+    }
+#   redis = {
+#     database = 0
+#     host = "localhost"
+#     port = 6379
+#     timeout = 60 seconds
+#     prefix = "kafkalagexporter"
+#     separator = ":"
+#     resolution = 1 minute
+#     retention = 1 day
+#     expiration = 1 day
+#   }
   }
+  client-group-id = "kafkalagexporter"
+  kafka-client-timeout = 10 seconds
+  clusters = []
+  watchers.strimzi = "false"
   metric-whitelist = [".*"]
 }
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -17,7 +17,6 @@ kafka-lag-exporter {
 #     timeout = 60 seconds
 #     prefix = "kafkalagexporter"
 #     separator = ":"
-#     resolution = 1 minute
 #     retention = 1 day
 #     expiration = 1 day
 #   }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,11 +1,14 @@
 kafka-lag-exporter {
   reporters.prometheus.port = 8000
+  reporters.prometheus.port = ${?KAFKA_LAG_EXPORTER_PORT}
   poll-interval = 30 seconds
+  poll-interval = ${?KAFKA_LAG_EXPORTER_POLL_INTERVAL_SECONDS}
   # Deprecated
   lookup-table-size = ${kafka-lag-exporter.lookup-table.memory.size}
   lookup-table = {
     memory = {
       size = 60
+      size = ${?KAFKA_LAG_EXPORTER_LOOKUP_TABLE_SIZE}
     }
 #   redis = {
 #     database = 0
@@ -20,9 +23,13 @@ kafka-lag-exporter {
 #   }
   }
   client-group-id = "kafkalagexporter"
+  client-group-id = ${?KAFKA_LAG_EXPORTER_CLIENT_GROUP_ID}
   kafka-client-timeout = 10 seconds
+  kafka-client-timeout = ${?KAFKA_LAG_EXPORTER_KAFKA_CLIENT_TIMEOUT_SECONDS}
   clusters = []
+  clusters = ${?KAFKA_LAG_EXPORTER_CLUSTERS}
   watchers.strimzi = "false"
+  watchers.strimzi = ${?KAFKA_LAG_EXPORTER_STRIMZI}
   metric-whitelist = [".*"]
 }
 

--- a/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
@@ -20,7 +20,6 @@ object AppConfig {
   def apply(config: Config): AppConfig = {
     val c = config.getConfig("kafka-lag-exporter")
     val pollInterval = c.getDuration("poll-interval").toScala
-    val lookupTableSize = c.getInt("lookup-table-size")
 
     val metricWhitelist = c.getStringList("metric-whitelist").asScala.toList
 
@@ -42,6 +41,7 @@ object AppConfig {
       }
     }
 
+    val lookupTable = LookupTableConfig(c)
     val clientGroupId = c.getString("client-group-id")
     val kafkaClientTimeout = c.getDuration("kafka-client-timeout").toScala
     val clusters =
@@ -106,7 +106,7 @@ object AppConfig {
 
     AppConfig(
       pollInterval,
-      lookupTableSize,
+      lookupTable,
       sinkConfigs,
       clientGroupId,
       kafkaClientTimeout,
@@ -195,7 +195,7 @@ final case class KafkaCluster(
 
 final case class AppConfig(
     pollInterval: FiniteDuration,
-    lookupTableSize: Int,
+    lookupTable: LookupTableConfig,
     sinkConfigs: List[SinkConfig],
     clientGroupId: String,
     clientTimeout: FiniteDuration,
@@ -208,9 +208,10 @@ final case class AppConfig(
         "  (none)"
       else clusters.map(_.toString).mkString("\n")
     val sinksString = sinkConfigs.mkString("")
+    val lookupTableString = lookupTable.toString()
     s"""
        |Poll interval: $pollInterval
-       |Lookup table size: $lookupTableSize
+       |$lookupTableString
        |Metrics whitelist: [${sinkConfigs.head.metricWhitelist.mkString(", ")}]
        |Admin client consumer group id: $clientGroupId
        |Kafka client timeout: $clientTimeout

--- a/src/main/scala/com/lightbend/kafkalagexporter/ConsumerGroupCollector.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/ConsumerGroupCollector.scala
@@ -327,46 +327,32 @@ object ConsumerGroupCollector {
     ): Unit = {
       topicPartitionTables.clear(evictedTps)
       for ((tp, point) <- snapshot.latestOffsets) {
+        def logAddPoint(msg: String) =
+          log.debug(
+            "  " + msg,
+            point.offset.toString,
+            point.time.toString,
+            tp.topic,
+            tp.partition.toString
+          )
         topicPartitionTables(tp).addPoint(point) match {
           case Inserted =>
-            log.debug(
-              "  Point ({}, {}) was added to the lookup table ({}, {})",
-              point.offset.toString,
-              point.time.toString,
-              tp.topic,
-              tp.partition.toString
-            )
+            logAddPoint("Point ({}, {}) was added to the lookup table ({}, {})")
           case NonMonotonic =>
-            log.debug(
-              "  Point ({}, {}) was not added to the lookup table ({}, {}) because it was not part of a monotonically increasing set",
-              point.offset.toString,
-              point.time.toString,
-              tp.topic,
-              tp.partition.toString
+            logAddPoint(
+              "Point ({}, {}) was not added to the lookup table ({}, {}) because it was not part of a monotonically increasing set"
             )
           case OutOfOrder =>
-            log.debug(
-              "  Point ({}, {}) was not added to the lookup table ({}, {}) because the time is older than the previous point",
-              point.offset.toString,
-              point.time.toString,
-              tp.topic,
-              tp.partition.toString
+            logAddPoint(
+              "Point ({}, {}) was not added to the lookup table ({}, {}) because the time is older than the previous point"
             )
           case UpdatedRetention =>
-            log.debug(
-              "  Point ({}, {}) was updated in the lookup table ({}, {}) because the last insert was too recent",
-              point.offset.toString,
-              point.time.toString,
-              tp.topic,
-              tp.partition.toString
+            logAddPoint(
+              "Point ({}, {}) was updated in the lookup table ({}, {}) because the last insert was too recent"
             )
           case UpdatedSameOffset =>
-            log.debug(
-              "  Point ({}, {}) was updated in the lookup table ({}, {}) because the offset was the same",
-              point.offset.toString,
-              point.time.toString,
-              tp.topic,
-              tp.partition.toString
+            logAddPoint(
+              "Point ({}, {}) was updated in the lookup table ({}, {}) because the offset was the same"
             )
         }
       }

--- a/src/main/scala/com/lightbend/kafkalagexporter/KafkaClusterManager.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/KafkaClusterManager.scala
@@ -76,7 +76,7 @@ object KafkaClusterManager {
 
         val config = ConsumerGroupCollector.CollectorConfig(
           appConfig.pollInterval,
-          appConfig.lookupTableSize,
+          appConfig.lookupTable,
           cluster
         )
         val collector = context.spawn(

--- a/src/main/scala/com/lightbend/kafkalagexporter/LookupTable.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/LookupTable.scala
@@ -5,20 +5,340 @@
 
 package com.lightbend.kafkalagexporter
 
+import com.lightbend.kafkalagexporter.LookupTable.LookupResult.Prediction
+import com.lightbend.kafkalagexporter.LookupTable.{
+  AddPointResult,
+  LookupResult,
+  Point
+}
+
+import java.time.Clock
+import com.lightbend.kafkalagexporter.LookupTableConfig.{
+  MemoryTableConfig,
+  RedisTableConfig
+}
+import com.redis.RedisClient
+
 import scala.collection.mutable
+import scala.util.Try
+import scala.util.control._
+
+sealed trait LookupTable {
+
+  /** Add the `Point` to the table. Note: `point.time` should be considered the
+    * "current" timestamp.
+    */
+  def addPoint(point: Point): AddPointResult
+  def lookup(offset: Long): LookupResult
+
+  /** Return the size of the lookup table.
+    */
+  def length: Long
+
+  /** Is this point the same reading as the last 2 most recent points?
+    */
+  def isFlat(point: Point): Boolean
+
+  // TOOD: add `pointAtIndex` to lookup by points by index
+
+  /** linear interpolation, solve for the x intercept given y (val), slope
+    * (dy/dx), and starting point (right)
+    */
+  final def predict(offset: Long, left: Point, right: Point): LookupResult = {
+    val dx = (right.time - left.time).toDouble
+    val dy = (right.offset - left.offset).toDouble
+    val Px = right.time.toDouble
+    val Dy = (right.offset - offset).toDouble
+    Prediction(Px - Dy * dx / dy)
+  }
+}
 
 object LookupTable {
-  case class Point(offset: Long, time: Long)
-  case class Table(limit: Int, points: mutable.Queue[Point]) {
-    import Table._
+  import Domain._
+  import LookupResult._
+  import AddPointResult._
+
+  final case class Point(offset: Long, time: Long)
+
+  sealed trait LookupResult
+  sealed trait AddPointResult
+
+  object LookupResult {
+    case object TooFewPoints extends LookupResult
+    case object LagIsZero extends LookupResult
+    final case class Prediction(time: Double) extends LookupResult
+  }
+
+  object AddPointResult {
+    case object OutOfOrder extends AddPointResult
+    case object NonMonotonic extends AddPointResult
+    case object UpdatedSameOffset extends AddPointResult
+    case object Inserted extends AddPointResult
+    case object UpdatedRetention extends AddPointResult
+  }
+
+  def apply(
+      clusterName: String,
+      topicPartition: TopicPartition,
+      config: LookupTableConfig
+  ): LookupTable = config match {
+    case c: RedisTableConfig  => RedisTable(clusterName, topicPartition, c)
+    case c: MemoryTableConfig => MemoryTable(c)
+  }
+
+  case class RedisTable(
+      clusterName: String,
+      tp: TopicPartition,
+      config: RedisTableConfig,
+      private[kafkalagexporter] val clock: Clock = Clock.systemUTC()
+  ) extends LookupTable {
+    import config._
+
+    val pointsKey = List(prefix, clusterName, tp.topic, tp.partition, "points")
+      .mkString(separator)
+    val lastUpdatedKey =
+      List(prefix, clusterName, tp.topic, tp.partition, "updated").mkString(
+        separator
+      )
+    val client = config.client
 
     /** Add the `Point` to the table.
       */
-    def addPoint(point: Point): Unit = mostRecentPoint() match {
+    def addPoint(point: Point): AddPointResult = {
+      mostRecentPoint() match {
+        // new point is out of order
+        case Right(mrp) if mrp.time >= point.time => OutOfOrder
+        // new point is not part of a monotonically increasing set
+        case Right(mrp) if mrp.offset > point.offset => NonMonotonic
+        // compress flat lines to a single segment
+        case Right(_) if isFlat(point) =>
+          // update the most recent point
+          removeExpiredPoints()
+          val times = client
+            .zrangebyscore(
+              key = pointsKey,
+              min = point.offset,
+              max = point.offset,
+              limit = Some((0, 2): (Int, Int))
+            )
+            .get
+          client.zremrangebyscore(
+            key = pointsKey,
+            start = point.offset,
+            end = point.offset
+          )
+          client.zadd(
+            pointsKey,
+            point.offset.toDouble,
+            times.minBy(_.toLong)
+          )
+          client.zadd(pointsKey, point.offset.toDouble, point.time)
+          expireKeys()
+          UpdatedSameOffset
+        case Right(mrp) =>
+          // dequeue oldest point if we've hit the limit
+          removeExpiredPoints()
+          val lastUpdatedTimestamp =
+            client.get(lastUpdatedKey).getOrElse("0")
+          Try(lastUpdatedTimestamp.toLong).toOption match {
+            case Some(lastUpdatedTimestamp)
+                if point.time - lastUpdatedTimestamp < resolution.toMillis =>
+              client.zremrangebyscore(
+                key = pointsKey,
+                start = mrp.offset,
+                end = mrp.offset
+              )
+              client.zadd(pointsKey, point.offset.toDouble, point.time)
+              expireKeys()
+              UpdatedRetention
+            case _ =>
+              client.zadd(pointsKey, point.offset.toDouble, point.time)
+              client.set(lastUpdatedKey, point.time)
+              expireKeys()
+              Inserted
+          }
+        // the table is empty or we filtered thru previous cases on the most recent point
+        case _ =>
+          // dequeue oldest point if we've hit the limit
+          removeExpiredPoints()
+          client.zadd(pointsKey, point.offset.toDouble, point.time)
+          client.set(lastUpdatedKey, point.time)
+          expireKeys()
+          Inserted
+      }
+    }
+
+    /** Predict the timestamp of a provided offset using interpolation if in the
+      * sliding window, or extrapolation if outside the sliding window.
+      */
+    def lookup(offset: Long): LookupResult = {
+      def estimate(): LookupResult = {
+        // Look in the sorted set for an exact point. It can happens by chance or during flattened range
+        client zrangebyscore (key = pointsKey, min = offset.toDouble, max =
+          offset.toDouble, limit = Some((0, 1): (Int, Int)), sortAs =
+          RedisClient.DESC) match {
+          // unexpected situation where the redis result is None
+          case None => sys.error("Point not found!")
+          case Some(points) if points.nonEmpty =>
+            return Prediction(points.head.toDouble)
+          case Some(_) => // Exact point not found, moving to range calculation
+        }
+
+        var left: Either[String, Point] = client.zrangebyscoreWithScore(
+          key = pointsKey,
+          min = 0,
+          max = offset.toDouble,
+          maxInclusive = false,
+          limit = Some((0, 1): (Int, Int)),
+          sortAs = RedisClient.DESC
+        ) match {
+          // unexpected situation where the redis result is None
+          case None => sys.error("Point not found!")
+          // find the left Point from the offset
+          case Some(lefts) if lefts.nonEmpty =>
+            Right(Point(lefts.head._2.toLong, lefts.head._1.toLong))
+          // offset is not between any two points in the table
+          case _ =>
+            // extrapolated = true
+            Left("Extrapolation required")
+        }
+
+        var right: Either[String, Point] = client.zrangebyscoreWithScore(
+          key = pointsKey,
+          min = offset.toDouble,
+          minInclusive = false,
+          max = Double.PositiveInfinity,
+          limit = Some((0, 1): (Int, Int)),
+          sortAs = RedisClient.ASC
+        ) match {
+          // unexpected situation where the redis result is None
+          case None => sys.error("Point not found!")
+          // find the right Point from the offset
+          case Some(rights) if rights.nonEmpty || left.isLeft =>
+            Right(Point(rights.head._2.toLong, rights.head._1.toLong))
+          // offset is not between any two points in the table
+          case _ =>
+            // extrapolated = true
+            Left("Extrapolation required")
+        }
+
+        // extrapolate given largest trendline we have available
+        if (left.isLeft || right.isLeft) {
+          left = oldestPoint()
+          right = mostRecentPoint()
+        }
+
+        if (left.isRight && right.isRight) {
+          predict(offset, left.right.get, right.right.get)
+        } else {
+          TooFewPoints
+        }
+      }
+
+      mostRecentPoint() match {
+        case Right(mrp) if mrp.offset == offset => LagIsZero
+        case _ if length < 2                    => TooFewPoints
+        case _                                  => estimate()
+      }
+    }
+
+    /** Expire keys in Redis with the configured TTL
+      */
+    def expireKeys(): Unit = {
+      client.expire(pointsKey, expiration.toSeconds.toInt)
+      client.expire(
+        lastUpdatedKey,
+        expiration.toSeconds.toInt
+      )
+    }
+
+    /** Remove points that are older than the configured retention
+      */
+    def removeExpiredPoints(): Unit = {
+      val currentTimestamp: Long = clock.instant().toEpochMilli
+      val loop = new Breaks
+      loop.breakable {
+        for (_ <- (0: Long) until length) {
+          oldestPoint() match {
+            case Left(_) => loop.break() // No Data
+            case Right(p) =>
+              if (currentTimestamp - retention.toMillis > p.time)
+                removeOldestPoint()
+              else loop.break()
+          }
+        }
+      }
+    }
+
+    /** Remove the oldest point
+      */
+    def removeOldestPoint(): Unit = {
+      client.zremrangebyrank(pointsKey, 0, 0)
+    }
+
+    /** Return the oldest `Point`. Returns either an error message, or the
+      * `Point`.
+      */
+    def oldestPoint(
+        start: Int = 0,
+        end: Int = 0
+    ): Either[String, Point] = {
+      val r = client
+        .zrangeWithScore(
+          key = pointsKey,
+          start = start,
+          end = end,
+          sortAs = RedisClient.ASC
+        )
+        .get
+      if (r.isEmpty) Left("No data in redis")
+      else Right(Point(r.head._2.toLong, r.head._1.toLong))
+    }
+
+    /** Return the size of the lookup table.
+      */
+    override def length: Long = client.zcount(pointsKey).getOrElse(0)
+
+    /** Return the most recently added `Point`. Returns either an error message,
+      * or the `Point`.
+      */
+    def mostRecentPoint(
+        start: Int = 0,
+        end: Int = 0
+    ): Either[String, Point] = {
+      val r = client
+        .zrangeWithScore(
+          key = pointsKey,
+          start = start,
+          end = end,
+          sortAs = RedisClient.DESC
+        )
+        .get
+      if (r.isEmpty) Left("No data in redis")
+      else Right(Point(r.head._2.toLong, r.head._1.toLong))
+    }
+
+    /** Is this point the same reading as the last 2 most recent points?
+      */
+    override def isFlat(point: Point): Boolean = {
+      length > 1 && mostRecentPoint().toOption.exists(
+        _.offset == point.offset
+      ) &&
+      mostRecentPoint(1, 1).toOption.exists(_.offset == point.offset)
+    }
+  }
+
+  case class MemoryTable(config: MemoryTableConfig) extends LookupTable {
+    val limit = config.size
+    val points = mutable.Queue[Point]()
+
+    /** Add the `Point` to the table.
+      */
+    def addPoint(point: Point): AddPointResult = mostRecentPoint() match {
       // new point is out of order
-      case Right(mrp) if mrp.time >= point.time =>
+      case Right(mrp) if mrp.time >= point.time => OutOfOrder
       // new point is not part of a monotonically increasing set
-      case Right(mrp) if mrp.offset > point.offset =>
+      case Right(mrp) if mrp.offset > point.offset => NonMonotonic
       // compress flat lines to a single segment
       // rather than run the table into a flat line, just move the right hand side out until we see variation again
       // Ex)
@@ -30,24 +350,24 @@ object LookupTable {
       //   If we still have not incremented the offset, replace the last entry.  Table now looks like:
       //     Point(offset = 200, time = 1000)
       //     Point(offset = 200, time = 3000)
-      case Right(mrp)
-          if mrp.offset == point.offset &&
-            points.length > 1 &&
-            points(points.length - 2).offset == point.offset =>
+      // compress flat lines to a single segment
+      case Right(_) if isFlat(point) =>
         // update the most recent point
         points(points.length - 1) = point
+        UpdatedSameOffset
       // the table is empty or we filtered thru previous cases on the most recent point
       case _ =>
         // dequeue oldest point if we've hit the limit (sliding window)
         if (points.length == limit) points.dequeue()
         points.enqueue(point)
+        Inserted
     }
 
     /** Predict the timestamp of a provided offset using interpolation if in the
       * sliding window, or extrapolation if outside the sliding window.
       */
-    def lookup(offset: Long): Result = {
-      def estimate(): Result = {
+    def lookup(offset: Long): LookupResult = {
+      def estimate(): LookupResult = {
         // search for two cells that contains the given offset
         val (left, right) = points.reverseIterator
           // create a sliding window of 2 elements with a step size of 1
@@ -62,13 +382,7 @@ object LookupTable {
             (points.head, points.last)
           }
 
-        // linear interpolation, solve for the x intercept given y (val), slope (dy/dx), and starting point (right)
-        val dx = (right.time - left.time).toDouble
-        val dy = (right.offset - left.offset).toDouble
-        val Px = (right.time).toDouble
-        val Dy = (right.offset - offset).toDouble
-
-        Prediction(Px - Dy * dx / dy)
+        predict(offset, left, right)
       }
 
       points.toList match {
@@ -87,14 +401,15 @@ object LookupTable {
       if (points.isEmpty) Left("No data in table")
       else Right(points.last)
     }
-  }
 
-  object Table {
-    def apply(limit: Int): Table = Table(limit, mutable.Queue[Point]())
+    /** Return the size of the lookup table.
+      */
+    override def length: Long = points.length
 
-    sealed trait Result
-    case object TooFewPoints extends Result
-    case object LagIsZero extends Result
-    final case class Prediction(time: Double) extends Result
+    override def isFlat(point: Point): Boolean =
+      length > 1 && mostRecentPoint().toOption.exists(
+        _.offset == point.offset
+      ) &&
+        points(points.length - 2).offset == point.offset
   }
 }

--- a/src/main/scala/com/lightbend/kafkalagexporter/LookupTableConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/LookupTableConfig.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 Sean Glover <https://seanglover.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import com.redis.RedisClient
+import com.typesafe.config.Config
+
+import scala.compat.java8.DurationConverters.DurationOps
+import scala.concurrent.duration.{Duration, DurationInt}
+
+sealed trait LookupTableConfig {
+  def close(): Unit = ()
+}
+
+object LookupTableConfig {
+  def apply(config: Config): LookupTableConfig = {
+    if (config.hasPath("lookup-table.redis")) {
+      new RedisTableConfig(config)
+    } else {
+      new MemoryTableConfig(config)
+    }
+  }
+
+  object MemoryTableConfig {
+    val SizeDefault = 60
+  }
+
+  final class MemoryTableConfig(config: Config) extends LookupTableConfig {
+    import MemoryTableConfig._
+
+    val table = config.getConfig("lookup-table.memory")
+    val size =
+      if (table.hasPath("size")) table.getInt("size")
+      else SizeDefault
+
+    override def toString: String = {
+      s"""Memory Lookup Table:
+         |  Size: $size
+     """.stripMargin
+    }
+  }
+
+  object RedisTableConfig {
+    val DatabaseDefault: Int = 0
+    val HostDefault: String = "localhost"
+    val PortDefault: Int = 6379
+    val TimeoutDefault: Duration = 60.seconds
+    val PrefixDefault: String = "kafka-lag-exporter"
+    val SeparatorDefault: String = ":"
+    val ResolutionDefault: Duration = 1.minute
+    val RetentionDefault: Duration = 1.day
+    val ExpirationDefault: Duration = 1.day
+  }
+
+  final class RedisTableConfig(config: Config) extends LookupTableConfig {
+    import RedisTableConfig._
+
+    val redis = config.getConfig("lookup-table.redis")
+    val database =
+      if (redis.hasPath("database"))
+        redis.getInt("database")
+      else DatabaseDefault
+
+    val host =
+      if (redis.hasPath("host"))
+        redis.getString("host")
+      else HostDefault
+
+    val port =
+      if (redis.hasPath("port"))
+        redis.getInt("port")
+      else PortDefault
+
+    val timeout =
+      if (redis.hasPath("timeout"))
+        redis.getDuration("timeout").toScala
+      else TimeoutDefault
+
+    val prefix =
+      if (redis.hasPath("prefix"))
+        redis.getString("prefix")
+      else PrefixDefault
+
+    val separator =
+      if (redis.hasPath("separator"))
+        redis.getString("separator")
+      else SeparatorDefault
+
+    val resolution =
+      if (redis.hasPath("resolution"))
+        redis.getDuration("resolution").toScala
+      else ResolutionDefault
+
+    val retention =
+      if (redis.hasPath("retention"))
+        redis.getDuration("retention").toScala
+      else RetentionDefault
+
+    val expiration =
+      if (redis.hasPath("expiration"))
+        redis.getDuration("expiration").toScala
+      else ExpirationDefault
+
+    val client = new RedisClient(
+      database = database,
+      host = host,
+      port = port,
+      timeout = timeout.toSeconds.toInt
+    )
+
+    override def close(): Unit = client.close()
+
+    override def toString: String = {
+      s"""Redis Lookup Table:
+         |  Database: $database
+         |  Host: $host
+         |  Port: $port
+         |  Timeout: $timeout
+         |  Prefix: $prefix
+         |  Separator: $separator
+         |  Resolution: $resolution
+         |  Retention: $retention
+         |  Expiration: $expiration
+     """.stripMargin
+    }
+  }
+
+}

--- a/src/main/scala/com/lightbend/kafkalagexporter/LookupTableConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/LookupTableConfig.scala
@@ -50,7 +50,6 @@ object LookupTableConfig {
     val TimeoutDefault: Duration = 60.seconds
     val PrefixDefault: String = "kafka-lag-exporter"
     val SeparatorDefault: String = ":"
-    val ResolutionDefault: Duration = 1.minute
     val RetentionDefault: Duration = 1.day
     val ExpirationDefault: Duration = 1.day
   }
@@ -89,11 +88,6 @@ object LookupTableConfig {
         redis.getString("separator")
       else SeparatorDefault
 
-    val resolution =
-      if (redis.hasPath("resolution"))
-        redis.getDuration("resolution").toScala
-      else ResolutionDefault
-
     val retention =
       if (redis.hasPath("retention"))
         redis.getDuration("retention").toScala
@@ -121,7 +115,6 @@ object LookupTableConfig {
          |  Timeout: $timeout
          |  Prefix: $prefix
          |  Separator: $separator
-         |  Resolution: $resolution
          |  Retention: $retention
          |  Expiration: $expiration
      """.stripMargin

--- a/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
@@ -77,7 +77,7 @@ class LookupTableSpec
 
   override def beforeEach(): Unit = {
     // make sure the Point table is empty
-    redisClient.del(table.pointsKey)
+    redisClient.del(table.key)
     testClock.setInstant(Instant.EPOCH)
   }
 

--- a/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
@@ -232,21 +232,21 @@ class LookupTableSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
         redisClient.del(table.pointsKey)
 
         table.addPoint(
-          Point(100, Clock.systemUTC().instant().toEpochMilli)
+          Point(100, 0)
         ) shouldBe Inserted
         table.addPoint(
-          Point(200, Clock.systemUTC().instant().toEpochMilli)
+          Point(200, 0)
         ) shouldBe UpdatedRetention
-        Thread.sleep(1000)
+
         table.addPoint(
-          Point(200, Clock.systemUTC().instant().toEpochMilli)
+          Point(200, 1000)
         ) shouldBe Inserted
-        Thread.sleep(1000)
+
         table.addPoint(
-          Point(200, Clock.systemUTC().instant().toEpochMilli)
+          Point(200, 2000)
         ) shouldBe UpdatedSameOffset
         table.addPoint(
-          Point(300, Clock.systemUTC().instant().toEpochMilli)
+          Point(300, 2000)
         ) shouldBe Inserted
 
         if (table.length != 3) {
@@ -255,10 +255,9 @@ class LookupTableSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
           )
         }
 
-        // Sleeping 1 seconds for the first point to expire
-        Thread.sleep(1000)
+        // Tick 1 second for the first point to expire
         table.addPoint(
-          Point(400, Clock.systemUTC().instant().toEpochMilli)
+          Point(400, 3000)
         ) shouldBe Inserted
 
         if (table.length != 3) {
@@ -267,9 +266,8 @@ class LookupTableSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
           )
         }
 
-        Thread.sleep(1000)
         table.addPoint(
-          Point(500, Clock.systemUTC().instant().toEpochMilli)
+          Point(500, 4000)
         ) shouldBe Inserted
 
         if (table.length != 2) {

--- a/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
@@ -201,40 +201,50 @@ class LookupTableSpec
           config = redisConfig,
           clock = testClock
         )
-
+        // Add a normal point
         table.addPoint(
           Point(100, 0)
         ) shouldBe Inserted
 
+        // Add first part of the flat line
         testClock.setInstant(Instant.ofEpochMilli(1000))
         table.addPoint(
           Point(200, 1000)
         ) shouldBe Inserted
 
+        // Add another point with same offet to make a flat line
+        testClock.setInstant(Instant.ofEpochMilli(1500))
+        table.addPoint(
+          Point(200, 1500)
+        ) shouldBe Inserted
+
+        // Add another point with the same offset, will extend the flat line
         testClock.setInstant(Instant.ofEpochMilli(2000))
         table.addPoint(
           Point(200, 2000)
         ) shouldBe Updated
 
+        testClock.setInstant(Instant.ofEpochMilli(3000))
         table.addPoint(
-          Point(300, 2001)
+          Point(300, 3000)
         ) shouldBe Inserted
 
+        // first point is more than 2 seconds old, so that let 3 points
         if (table.length != 3) {
           fail(
-            s"Expected table to limit to 3 entries (current is ${table.length})"
+            s"Expected table to limit to 3 entry (current is ${table.length})"
           )
         }
 
-        testClock.setInstant(Instant.ofEpochMilli(3001))
-        // tick 1 second for the first point to expire
+        testClock.setInstant(Instant.ofEpochMilli(4001))
+        // tick 1+ second for the first point to expire
         table.addPoint(
-          Point(400, 3001)
+          Point(400, 4000)
         ) shouldBe Inserted
 
-        if (table.length != 3) {
+        if (table.length != 2) {
           fail(
-            s"Expected table to limit to 3 entries (current is ${table.length})"
+            s"Expected table to limit to 2 entries (current is ${table.length})"
           )
         }
         // tick > 1 interval of 1 second since most recent point
@@ -243,9 +253,9 @@ class LookupTableSpec
           Point(500, 4002)
         ) shouldBe Inserted
 
-        if (table.length != 2) {
+        if (table.length != 3) {
           fail(
-            s"Expected table to limit to 2 entries (current is ${table.length})"
+            s"Expected table to limit to 3 entries (current is ${table.length})"
           )
         }
       }

--- a/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
@@ -5,22 +5,356 @@
 
 package com.lightbend.kafkalagexporter
 
-import com.lightbend.kafkalagexporter.LookupTable.Table.{
+import com.lightbend.kafkalagexporter.ConsumerGroupCollector.CollectorConfig
+import com.lightbend.kafkalagexporter.LookupTable.AddPointResult.{
+  Inserted,
+  NonMonotonic,
+  OutOfOrder,
+  UpdatedRetention,
+  UpdatedSameOffset
+}
+import com.lightbend.kafkalagexporter.LookupTable.LookupResult.{
   LagIsZero,
   Prediction,
   TooFewPoints
 }
+import com.lightbend.kafkalagexporter.LookupTableConfig.RedisTableConfig
+
+import java.time.{Clock, Instant, ZoneId}
+import com.redis.RedisClient
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
+import scala.concurrent.duration.DurationInt
 
-class LookupTableSpec extends AnyFreeSpec with Matchers {
+class LookupTableSpec extends AnyFreeSpec with Matchers with BeforeAndAfterAll {
 
   import com.lightbend.kafkalagexporter.LookupTable._
 
+  private val image = DockerImageName.parse("redis").withTag("5.0.3-alpine")
+  private val container: GenericContainer[_] = {
+    val c = new GenericContainer(image)
+    c.withExposedPorts(6379)
+    c
+  }
+
+  var redisConfig: RedisTableConfig = null
+  var redisClient: RedisClient = null
+  var config: CollectorConfig = null
+  var table: RedisTable = null
+
+  override def beforeAll(): Unit = {
+    container.start()
+//    redisConfig = LookupTableConfig.RedisTableConfig(
+//      resolution = 0.second,
+//      retention = Long.MaxValue.nanoseconds,
+//      expiration = 30.minute,
+//      host = container.getHost,
+//      port = container.getFirstMappedPort
+//    )
+    redisConfig = new LookupTableConfig.RedisTableConfig(
+      ConfigFactory.parseString(s"""lookup-table.redis = {
+           |  resolution = 0 seconds
+           |  retention = 1 day
+           |  expiration = 30 minutes
+           |  host = "${container.getHost}"
+           |  port = ${container.getFirstMappedPort}
+           |}""".stripMargin)
+    )
+    redisClient = redisConfig.client
+    config = ConsumerGroupCollector.CollectorConfig(
+      0.second,
+      redisConfig,
+      KafkaCluster("default", ""),
+      Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault())
+    )
+    table = LookupTable.RedisTable(
+      config.cluster.name,
+      Domain.TopicPartition("topic", 0),
+      redisConfig,
+      Clock.fixed(Instant.EPOCH, ZoneId.of("UTC"))
+    )
+  }
+
+  override def afterAll(): Unit = {
+    container.stop()
+  }
+
   "LookupTable" - {
-    "lookupOffset" - {
+    "RedisTable" - {
       "invalids and edge conditions" in {
-        val table = Table(10)
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        if (table.length > 0) {
+          fail(s"New table should be empty $table")
+        }
+
+        table.lookup(0) shouldBe TooFewPoints
+
+        // Point(offset: Long, time: Long)
+        table.addPoint(Point(100, 100))
+
+        table.lookup(0) shouldBe TooFewPoints
+
+        // invalid points.
+        // should be monotonically increasing in time and offset
+        table.addPoint(Point(110, 90))
+        table.addPoint(Point(90, 110))
+        table.addPoint(Point(0, 0))
+        table.addPoint(Point(110, -1))
+        table.addPoint(Point(-1, 110))
+        table.addPoint(Point(-1, -1))
+
+        if (table.length != 1) {
+          fail(s"Expected out of order to be skipped $table")
+        }
+      }
+
+      "square lookups, x == y" in {
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        table.addPoint(Point(100, 100)) shouldBe Inserted
+        table.addPoint(Point(200, 200)) shouldBe Inserted
+
+        table.length shouldEqual 2
+
+        val tests = List[Long](150, 190, 110, // interpolation
+          10, 0, -100, // extrapolation under the table
+          300, 100 // extrapolation over the table
+        )
+
+        tests.foreach(expected =>
+          table.lookup(expected) shouldBe Prediction(expected)
+        )
+      }
+
+      "lookups with flat sections" in {
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        table.addPoint(Point(100, 30))
+        table.addPoint(Point(200, 60))
+        table.addPoint(Point(200, 120))
+        table.addPoint(Point(200, 700))
+
+        if (table.length != 3) {
+          fail(
+            s"Expected table to have 3 entries (it has ${table.length}). Table should truncate compress middle value for offset 200."
+          )
+        }
+
+        table.addPoint(Point(300, 730))
+        table.addPoint(Point(300, 9000))
+        table.addPoint(Point(400, 9030))
+
+        table.lookup(199) shouldBe Prediction(59.7)
+        table.lookup(200) shouldBe Prediction(
+          700
+        ) // should find the latest (right hand side) of the flat section
+        table.lookup(201) shouldBe Prediction(700.3)
+        table.lookup(250) shouldBe Prediction(715)
+        table.lookup(299) shouldBe Prediction(729.7)
+        table.lookup(300) shouldBe Prediction(9000) // ditto
+        table.lookup(301) shouldBe Prediction(9000.3)
+      }
+
+      "lookups when table only contains a flat section with offsets same as lookup" in {
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        table.addPoint(Point(0, 0))
+        table.addPoint(Point(0, 100))
+
+        table.lookup(0) shouldBe LagIsZero
+      }
+
+      "lookup is zero when when table has a single element the same as the last group offset" in {
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        table.addPoint(Point(0, 100))
+        table.lookup(0) shouldBe LagIsZero
+      }
+
+      "infinite lookups, dy == 0, flat curve/no growth" in {
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        table.addPoint(Point(100, 100))
+        table.addPoint(Point(100, 200))
+        table.addPoint(Point(100, 300))
+        table.addPoint(Point(100, 400))
+
+        if (table.length != 2) {
+          fail(s"Expected flat entries to compress to a single entry $table")
+        }
+
+        if (table.mostRecentPoint().right.get.time != 400) {
+          fail(s"Expected compressed table to have last timestamp $table")
+        }
+
+        table.lookup(99) shouldBe Prediction(
+          Double.NegativeInfinity
+        )
+        table.lookup(101) shouldBe Prediction(
+          Double.PositiveInfinity
+        )
+      }
+
+      "table retention and resolution" in {
+        val _redisTableConfig = new LookupTableConfig.RedisTableConfig(
+          ConfigFactory.parseString(s"""lookup-table.redis = {
+               |  resolution = 1 seconds
+               |  retention = 2 seconds
+               |  expiration = 30 minutes
+               |  host = "${container.getHost}"
+               |  port = ${container.getFirstMappedPort}
+               |}""".stripMargin)
+        )
+        val _config = ConsumerGroupCollector.CollectorConfig(
+          0.second,
+          _redisTableConfig,
+          KafkaCluster("default", ""),
+          Clock.fixed(Instant.ofEpochMilli(0), ZoneId.systemDefault())
+        )
+        val table = LookupTable.RedisTable(
+          _config.cluster.name,
+          Domain.TopicPartition("topic", 0),
+          _redisTableConfig
+        )
+
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        table.addPoint(
+          Point(100, Clock.systemUTC().instant().toEpochMilli)
+        ) shouldBe Inserted
+        table.addPoint(
+          Point(200, Clock.systemUTC().instant().toEpochMilli)
+        ) shouldBe UpdatedRetention
+        Thread.sleep(1000)
+        table.addPoint(
+          Point(200, Clock.systemUTC().instant().toEpochMilli)
+        ) shouldBe Inserted
+        Thread.sleep(1000)
+        table.addPoint(
+          Point(200, Clock.systemUTC().instant().toEpochMilli)
+        ) shouldBe UpdatedSameOffset
+        table.addPoint(
+          Point(300, Clock.systemUTC().instant().toEpochMilli)
+        ) shouldBe Inserted
+
+        if (table.length != 3) {
+          fail(
+            s"Expected table to limit to 3 entries (current is ${table.length})"
+          )
+        }
+
+        // Sleeping 1 seconds for the first point to expire
+        Thread.sleep(1000)
+        table.addPoint(
+          Point(400, Clock.systemUTC().instant().toEpochMilli)
+        ) shouldBe Inserted
+
+        if (table.length != 3) {
+          fail(
+            s"Expected table to limit to 3 entries (current is ${table.length})"
+          )
+        }
+
+        Thread.sleep(1000)
+        table.addPoint(
+          Point(500, Clock.systemUTC().instant().toEpochMilli)
+        ) shouldBe Inserted
+
+        if (table.length != 2) {
+          fail(
+            s"Expected table to limit to 2 entries (current is ${table.length})"
+          )
+        }
+      }
+
+      "normal case, steady timestamps, different val rates" in {
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        table.addPoint(Point(0, 0))
+        table.addPoint(Point(10, 1))
+        table.addPoint(Point(200, 2))
+        table.addPoint(Point(3000, 3))
+        table.addPoint(Point(40000, 4))
+
+        if (table.length != 5) {
+          fail(s"Expected table to limit to 5 entries $table")
+        }
+
+        table.lookup(1600) shouldBe Prediction(2.5)
+        table.lookup(0) shouldBe Prediction(0.0)
+        table.lookup(1) shouldBe Prediction(0.09999999999999998)
+        table.lookup(9) shouldBe Prediction(0.9)
+        table.lookup(10) shouldBe Prediction(1)
+        table.lookup(200) shouldBe Prediction(2)
+        table.lookup(2999) shouldBe Prediction(2.9996428571428573)
+        table.lookup(3000) shouldBe Prediction(3)
+        table.lookup(3001) shouldBe Prediction(3.000027027027027)
+        table.lookup(40000) shouldBe LagIsZero
+        // extrapolation
+        table.lookup(-10000) shouldBe Prediction(-1)
+        table.lookup(50000) shouldBe Prediction(5)
+      }
+
+      "mostRecentPoint" in {
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        val result = table.mostRecentPoint()
+        if (result.isRight) {
+          fail(
+            s"Expected most recent point on empty table to fail with an error, but got $result"
+          )
+        }
+
+        for (n <- 0 to 10) {
+          table.addPoint(Point(n, n * 10))
+          val result = table.mostRecentPoint()
+
+          if (result.isLeft) {
+            fail(
+              s"Most recent point on $table returned error unexpectedly: $result"
+            )
+          }
+
+          if (n != result.right.get.offset) {
+            fail(
+              s"Most recent point on $table expected $n, but got ${result.right.get.offset}"
+            )
+          }
+        }
+      }
+
+      "redis return invalid results" in {
+        // Make sure the Point table is empty
+        redisClient.del(table.pointsKey)
+
+        table.addPoint(Point(100, 100)) shouldBe Inserted
+        table.addPoint(Point(110, 90)) shouldBe OutOfOrder
+        table.addPoint(Point(90, 110)) shouldBe NonMonotonic
+
+        table.lookup(120) shouldBe TooFewPoints
+      }
+    }
+
+    "MemoryTable" - {
+      "invalids and edge conditions" in {
+        val tableConfig = new LookupTableConfig.MemoryTableConfig(
+          ConfigFactory.parseString("lookup-table.memory.size = 10")
+        )
+        val table = LookupTable.MemoryTable(tableConfig)
 
         if (table.points.nonEmpty) {
           fail(s"New table should be empty $table")
@@ -48,7 +382,10 @@ class LookupTableSpec extends AnyFreeSpec with Matchers {
       }
 
       "square lookups, x == y" in {
-        val table = Table(10)
+        val tableConfig = new LookupTableConfig.MemoryTableConfig(
+          ConfigFactory.parseString("lookup-table.memory.size = 10")
+        )
+        val table = LookupTable.MemoryTable(tableConfig)
 
         table.addPoint(Point(100, 100))
         table.addPoint(Point(200, 200))
@@ -64,7 +401,10 @@ class LookupTableSpec extends AnyFreeSpec with Matchers {
       }
 
       "lookups with flat sections" in {
-        val table = Table(10)
+        val tableConfig = new LookupTableConfig.MemoryTableConfig(
+          ConfigFactory.parseString("lookup-table.memory.size = 10")
+        )
+        val table = LookupTable.MemoryTable(tableConfig)
 
         table.addPoint(Point(100, 30))
         table.addPoint(Point(200, 60))
@@ -93,7 +433,10 @@ class LookupTableSpec extends AnyFreeSpec with Matchers {
       }
 
       "lookups when table only contains a flat section with offsets same as lookup" in {
-        val table = Table(5)
+        val tableConfig = new LookupTableConfig.MemoryTableConfig(
+          ConfigFactory.parseString("lookup-table.memory.size = 5")
+        )
+        val table = LookupTable.MemoryTable(tableConfig)
 
         table.addPoint(Point(0, 0))
         table.addPoint(Point(0, 100))
@@ -102,13 +445,19 @@ class LookupTableSpec extends AnyFreeSpec with Matchers {
       }
 
       "lookup is zero when when table has a single element the same as the last group offset" in {
-        val table = Table(5)
+        val tableConfig = new LookupTableConfig.MemoryTableConfig(
+          ConfigFactory.parseString("lookup-table.memory.size = 5")
+        )
+        val table = LookupTable.MemoryTable(tableConfig)
         table.addPoint(Point(0, 100))
         table.lookup(0) shouldBe LagIsZero
       }
 
       "infinite lookups, dy == 0, flat curve/no growth" in {
-        val table = Table(10)
+        val tableConfig = new LookupTableConfig.MemoryTableConfig(
+          ConfigFactory.parseString("lookup-table.memory.size = 10")
+        )
+        val table = LookupTable.MemoryTable(tableConfig)
 
         table.addPoint(Point(100, 100))
         table.addPoint(Point(100, 200))
@@ -128,7 +477,10 @@ class LookupTableSpec extends AnyFreeSpec with Matchers {
       }
 
       "normal case, table truncates, steady timestamps, different val rates" in {
-        val table = Table(5)
+        val tableConfig = new LookupTableConfig.MemoryTableConfig(
+          ConfigFactory.parseString("lookup-table.memory.size = 5")
+        )
+        val table = LookupTable.MemoryTable(tableConfig)
 
         table.addPoint(Point(-2, -2))
         table.addPoint(Point(-1, -1))
@@ -161,33 +513,36 @@ class LookupTableSpec extends AnyFreeSpec with Matchers {
         table.lookup(-10000) shouldBe Prediction(-1)
         table.lookup(50000) shouldBe Prediction(5)
       }
-    }
 
-    "mostRecentPoint" in {
-      val table = Table(5)
-
-      val result = table.mostRecentPoint()
-
-      if (result.isRight) {
-        fail(
-          s"Expected most recent point on empty table to fail with an error, but got $result"
+      "mostRecentPoint" in {
+        val tableConfig = new LookupTableConfig.MemoryTableConfig(
+          ConfigFactory.parseString("lookup-table.memory.size = 5")
         )
-      }
+        val table = LookupTable.MemoryTable(tableConfig)
 
-      for (n <- 0 to 10) {
-        table.addPoint(Point(n, n * 10))
         val result = table.mostRecentPoint()
 
-        if (result.isLeft) {
+        if (result.isRight) {
           fail(
-            s"Most recent point on $table returned error unexpectedly: $result"
+            s"Expected most recent point on empty table to fail with an error, but got $result"
           )
         }
 
-        if (n != result.right.get.offset) {
-          fail(
-            s"Most recent point on $table expected $n, but got ${result.right.get.offset}"
-          )
+        for (n <- 0 to 10) {
+          table.addPoint(Point(n, n * 10))
+          val result = table.mostRecentPoint()
+
+          if (result.isLeft) {
+            fail(
+              s"Most recent point on $table returned error unexpectedly: $result"
+            )
+          }
+
+          if (n != result.right.get.offset) {
+            fail(
+              s"Most recent point on $table expected $n, but got ${result.right.get.offset}"
+            )
+          }
         }
       }
     }

--- a/src/test/scala/com/lightbend/kafkalagexporter/TestClock.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/TestClock.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
+ * Copyright (C) 2022 Sean Glover <https://seanglover.com>
+ */
+
+package com.lightbend.kafkalagexporter
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+
+class TestClock extends Clock {
+
+  @volatile private var _instant = roundToMillis(Instant.EPOCH)
+
+  override def getZone: ZoneId = ZoneOffset.UTC
+
+  override def withZone(zone: ZoneId): Clock =
+    throw new UnsupportedOperationException("withZone not supported")
+
+  override def instant(): Instant =
+    _instant
+
+  def setInstant(newInstant: Instant): Unit =
+    _instant = roundToMillis(newInstant)
+
+  def tick(duration: Duration): Instant = {
+    val newInstant = roundToMillis(_instant.plus(duration))
+    _instant = newInstant
+    newInstant
+  }
+
+  private def roundToMillis(i: Instant): Instant = {
+    // algo taken from java.time.Clock.tick
+    val epochMilli = i.toEpochMilli
+    Instant.ofEpochMilli(epochMilli - Math.floorMod(epochMilli, 1L))
+  }
+
+}

--- a/src/test/scala/com/lightbend/kafkalagexporter/TestData.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/TestData.scala
@@ -6,6 +6,7 @@
 package com.lightbend.kafkalagexporter
 
 import com.lightbend.kafkalagexporter.Domain._
+import com.typesafe.config.ConfigFactory
 
 import org.apache.kafka.common.Node
 
@@ -61,6 +62,9 @@ trait TestData {
     topic2Partition0.topic,
     topic2Partition0.partition
   )
-  val lookupTableOnePoint = LookupTable.Table(20)
+  val lookupTableOnePointConfig = new LookupTableConfig.MemoryTableConfig(
+    ConfigFactory.parseString("lookup-table.memory.size = 20")
+  )
+  val lookupTableOnePoint = LookupTable.MemoryTable(lookupTableOnePointConfig)
   lookupTableOnePoint.addPoint(LookupTable.Point(100, 100))
 }


### PR DESCRIPTION
The lag in second metrics is really what make that exporter different from the others.
After using it for a while, I noticed the lag was really accurate when the points were inside the lookup table, but the extrapolation was really not that precise and was often leading to really high numbers.
One of the reason is when the extrapolation happens, it is done based on the entire lookup table, which works well if you have a consumer speed that don't change too much, but doesn't work well when you have a consumer that spikes.

Because of that, I tried to increase the size of the in-memory lookup table, to be able to fit between one day and one week of data but when the exporter was restarting, it took a very long time to build the lookup table.

This lead to change change, which is basically adding an option to move the lookup table in Redis, so the lookup table could be bigger and will not be affected by restart anymore.

The option is under a `redis` category:
| Key          | Default                | Required | Description                                                                                                         |
|--------------|------------------------|----------|---------------------------------------------------------------------------------------------------------------------|
| `enabled`    | `"false"`              | No       | Switch to enable or disable the Redis table (if enabled, the memory tables will not be created).                    |
| `database`   | `0`                    | No       | Redis database number.                                                                                              |
| `host`       | `"localhost"`          | No       | Redis server to use.                                                                                                |
| `port`       | `6379`                 | No       | Redis port to use.                                                                                                  |
| `timeout`    | `60`                   | No       | Redis connection timeout.                                                                                           |
| `prefix`     | `"kafka-lag-exporter"` | No       | Prefix used by all the keys.                                                                                        |
| `separator`  | `":"`                  | No       | Separator used to build the keys.                                                                                   |
| `retention`  | `"1 day"`              | No       | Retention of the lookup table. Points will get removed from the table after that.                                   |
| `expiration` | `"1 day"`              | No       | Expiration (TTL) of all the keys                                                                                    |
