### PR TITLE
Move image pull secrets to pod spec

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -41,6 +41,10 @@ spec:
       serviceAccountName: {{ include "kafka-lag-exporter.fullname" . }}-serviceaccount
       {{- end }}
       {{- end }}
+      imagePullSecrets:
+        {{ toYaml .Values.image.pullSecrets | indent 8 }}
+        {{- end }}
+        {{- if .Values.env }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.image.digest }}
@@ -50,10 +54,6 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.image.pullSecrets }}
-          imagePullSecrets:
-{{ toYaml .Values.image.pullSecrets | indent 10 }}
-          {{- end }}
-          {{- if .Values.env }}
           env:
 {{ toYaml .Values.env | indent 10 }}
           {{- end }}

--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -41,10 +41,10 @@ spec:
       serviceAccountName: {{ include "kafka-lag-exporter.fullname" . }}-serviceaccount
       {{- end }}
       {{- end }}
+      {{- if .Values.image.pullSecrets }}
       imagePullSecrets:
         {{ toYaml .Values.image.pullSecrets | indent 8 }}
-        {{- end }}
-        {{- if .Values.env }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- if .Values.image.digest }}
@@ -53,7 +53,7 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.image.pullSecrets }}
+          {{- if .Values.env }}
           env:
 {{ toYaml .Values.env | indent 10 }}
           {{- end }}


### PR DESCRIPTION
fixes: #339 

`imagePullSecrets` is indeed not referenced in the container spec.

https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#container-v1-core