### PR TITLE
Make possible to define bootstrap-brokers via Environment Varible

### DIFF
--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -19,7 +19,7 @@ data:
         {{- range $cluster := .Values.clusters }}
         {
           name = "{{ $cluster.name }}"
-          bootstrap-brokers = "{{ $cluster.bootstrapBrokers }}"
+          bootstrap-brokers = {{ $cluster.bootstrapBrokers }}
           {{- if $cluster.groupWhitelist }}
           group-whitelist = [
             {{- $lastIndex := sub (len $cluster.groupWhitelist) 1}}


### PR DESCRIPTION
We have Broker endpoints in AWS SSM Parameter store and syncing them to Kubernetes cluster via "external secret" controller. Therefore we would like to pass env variable reference to the configmap, so it can be evaluated during runtime.

This quotation prevents the subtitution of environment variable reference.

I believe such usecase isn't specific for our company and it might help others.