### PR TITLE
Update dependencies to avoid known vulnerabilities

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Version {
   val Scala = "2.12.15"
   val Akka = "2.6.19"
-  val Prometheus = "0.15.0"
+  val Prometheus = "0.16.0"
   val Fabric8 = "4.9.1"
   val Kafka = "2.5.0"
   val Testcontainers = "1.17.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Version {
   val Akka = "2.6.19"
   val Prometheus = "0.16.0"
   val Fabric8 = "4.9.1"
-  val Kafka = "2.5.0"
+  val Kafka = "3.2.1"
   val Testcontainers = "1.17.3"
   val IAMAuth = "1.1.4"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Version {
   val Prometheus = "0.15.0"
   val Fabric8 = "4.9.1"
   val Kafka = "2.5.0"
-  val Testcontainers = "1.16.3"
+  val Testcontainers = "1.17.3"
   val IAMAuth = "1.1.4"
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Version {
   val Scala = "2.12.15"
   val Akka = "2.6.19"
   val Prometheus = "0.16.0"
-  val Fabric8 = "4.9.1"
+  val Fabric8 = "4.11.2"
   val Kafka = "3.2.1"
   val Testcontainers = "1.17.3"
   val IAMAuth = "1.1.4"

--- a/src/main/scala/com/lightbend/kafkalagexporter/watchers/StrimziClient.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/watchers/StrimziClient.scala
@@ -9,7 +9,7 @@ import java.lang
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.lightbend.kafkalagexporter.KafkaCluster
-import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinitionBuilder
+import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinitionBuilder
 import io.fabric8.kubernetes.client.{Watcher => FWatcher, _}
 import io.fabric8.kubernetes.client.dsl.FilterWatchListMultiDeletable
 import io.fabric8.kubernetes.internal.KubernetesDeserializer


### PR DESCRIPTION
Ref #376 376

This PR will upgrade Java dependencies and silence all warnings for Java-related vulnerabilities. `sbt test` passes locally with `docker-compose`.

Note that there are still many vulnerability warnings left, all related to the `ubi8` image.