### PR TITLE
Fix "Integration tests using Minikube"

### DIFF
--- a/examples/k8s/strimzi-kafka-cluster.yaml
+++ b/examples/k8s/strimzi-kafka-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: strimzi-kafka-cluster
 spec:
   kafka:
-    version: 3.0.0
+    version: 3.2.0
     replicas: 1
     listeners:
       - name: plain
@@ -25,7 +25,7 @@ spec:
       transaction.state.log.min.isr: 1
       default.replication.factor: 1
       min.insync.replicas: 1
-      inter.broker.protocol.version: "3.0"
+      inter.broker.protocol.version: "3.2"
     storage:
       type: ephemeral
   zookeeper:


### PR DESCRIPTION
I tried to run the Minikube tests locally, and noticed from the Strimzi logs:

```
Unsupported Kafka.spec.kafka.version: 3.0.0. Supported versions are: [3.1.0, 3.1.1, 3.2.0]
```

Changing the version to `3.2.0` in `examples/k8s/strimzi-kafka-cluster.yaml` appears to make the tests run again.
