### PR TITLE
Update Ubuntu on the workflows, as 18.04 is deprecated on GitHub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   test:
     name: Build and Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:
@@ -44,7 +44,7 @@ jobs:
 
   local-test:
     name: Integration tests using Testcontainers
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:
@@ -76,7 +76,7 @@ jobs:
 
   minikube-test:
     name: Integration tests using Minikube
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:
@@ -126,7 +126,7 @@ jobs:
 
   build-docker:
     name: Build Docker Image
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:
@@ -158,7 +158,7 @@ jobs:
 
   helm-chart:
     name: Package Helm Chart
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     # runs on main repo only
     if: github.repository == 'seglo/kafka-lag-exporter'
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
I got errors when running the workloads on my fork, stating that "This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on December 1st, 2022." This PR upgrades Ubuntu for the workflows.