### PR TITLE
(chart) Make values in lookup.redis optional

### DIFF
--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -75,14 +75,30 @@ data:
       {{- if .Values.lookup.redis.enabled }}
       {{- with .Values.lookup.redis }}
       lookup-table.redis = {
-        host = {{ .host | quote }}
-        database = {{ .database | quote }}
-        port = {{ .port | quote }}
-        timeout = {{ .timeout }}
-        prefix = {{ .prefix | quote }}
-        separator = {{ .separator | quote }}
-        retention = {{ .retention | quote }}
-        expiration = {{ .expiration | quote }}
+        {{- with .host }}
+        host = {{ . }}
+        {{- end }}
+        {{- with .database }}
+        database = {{ . }}
+        {{- end }}
+        {{- with .port }}
+        port = {{ . }}
+        {{- end }}
+        {{- with .timeout }}
+        timeout = {{ . }}
+        {{- end }}
+        {{- with .prefix }}
+        prefix = {{ . }}
+        {{- end }}
+        {{- with .separator }}
+        separator = {{ . }}
+        {{- end }}
+        {{- with .retention }}
+        retention = {{ . }}
+        {{- end }}
+        {{- with .expiration }}
+        expiration = {{ . }}
+        {{- end }}
       }
       {{- end }}
       {{- else }}


### PR DESCRIPTION
Right now, if you don't specify all the values for lookup.redis.* in the helm chart, the pod doesn't start.

An example of configuration if you specify only the host:
`
      lookup-table.redis = {
        host = myhost
        database = 
        port = 
        timeout = 
        prefix = 
        separator = 
        retention = 
        expiration = 
      }
`

The setting without a value should not be added, so they will inherits from the defaults in the code.