### PR TITLE
(chart) Always add checksum/config annotation

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -19,11 +19,11 @@ spec:
         {{- if .Values.podExtraLabels }}
         {{- tpl (toYaml .Values.podExtraLabels) . | nindent 8 }}
         {{- end }}
-      {{- if .Values.podAnnotations }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/030-ConfigMap.yaml") . | sha256sum }}
-{{ tpl (toYaml .Values.podAnnotations) . | indent 8 }}
-      {{- end }}
+        {{- if .Values.podAnnotations }}
+        {{- tpl (toYaml .Values.podAnnotations) . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.hostAliases }}
       hostAliases:


### PR DESCRIPTION
The checksum/config annotation is missing in the deployment if podAnnotations is empty (that's the default value).
That make the pod not restart automatically when there is a configuration change.

The workaround is to add something in the podAnnotations, but this small code change make it simpler.