### PR TITLE
Add kafka-retries parameter

### DIFF
--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -11,6 +11,7 @@ data:
       poll-interval = {{ .Values.pollIntervalSeconds }} seconds
       client-group-id = "{{ .Values.clientGroupId }}"
       kafka-client-timeout = {{ .Values.kafkaClientTimeoutSeconds }} seconds
+      kafka-retries = {{ .Values.kafkaRetries }}
       clusters = [
         {{- range $cluster := .Values.clusters }}
         {

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -52,6 +52,8 @@ pollIntervalSeconds: 30
 clientGroupId: "kafkalagexporter"
 ## The timeout when communicating with Kafka clusters
 kafkaClientTimeoutSeconds: 10
+## The number of retry when getting the consumer groups
+kafkaRetries: 0
 ## Reporters will send metrics to time series databases
 reporters:
   prometheus:

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -25,6 +25,8 @@ kafka-lag-exporter {
   client-group-id = ${?KAFKA_LAG_EXPORTER_CLIENT_GROUP_ID}
   kafka-client-timeout = 10 seconds
   kafka-client-timeout = ${?KAFKA_LAG_EXPORTER_KAFKA_CLIENT_TIMEOUT_SECONDS}
+  kafka-retries = 0
+  kafka-retries = ${?KAFKA_LAG_EXPORTER_KAFKA_RETRIES}
   clusters = []
   clusters = ${?KAFKA_LAG_EXPORTER_CLUSTERS}
   watchers.strimzi = "false"

--- a/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/AppConfig.scala
@@ -44,6 +44,7 @@ object AppConfig {
     val lookupTable = LookupTableConfig(c)
     val clientGroupId = c.getString("client-group-id")
     val kafkaClientTimeout = c.getDuration("kafka-client-timeout").toScala
+    val kafkaRetries = c.getInt("kafka-retries")
     val clusters =
       c.getConfigList("clusters").asScala.toList.map { clusterConfig =>
         val consumerProperties =
@@ -110,6 +111,7 @@ object AppConfig {
       sinkConfigs,
       clientGroupId,
       kafkaClientTimeout,
+      kafkaRetries,
       clusters,
       strimziWatcher
     )
@@ -199,6 +201,7 @@ final case class AppConfig(
     sinkConfigs: List[SinkConfig],
     clientGroupId: String,
     clientTimeout: FiniteDuration,
+    retries: Int,
     clusters: List[KafkaCluster],
     strimziWatcher: Boolean
 ) {
@@ -215,6 +218,7 @@ final case class AppConfig(
        |Metrics whitelist: [${sinkConfigs.head.metricWhitelist.mkString(", ")}]
        |Admin client consumer group id: $clientGroupId
        |Kafka client timeout: $clientTimeout
+       |Kafka retries: $retries
        |$sinksString
        |Statically defined Clusters:
        |$clusterString

--- a/src/main/scala/com/lightbend/kafkalagexporter/MainApp.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/MainApp.scala
@@ -33,7 +33,12 @@ object MainApp extends App {
     val appConfig = AppConfig(config)
 
     val clientCreator = (cluster: KafkaCluster) =>
-      KafkaClient(cluster, appConfig.clientGroupId, appConfig.clientTimeout)(
+      KafkaClient(
+        cluster,
+        appConfig.clientGroupId,
+        appConfig.clientTimeout,
+        appConfig.retries
+      )(
         kafkaClientEc
       )
 


### PR DESCRIPTION
I noticed that in some of my clusters, the exporter doesn't start.

> 2022-10-05 01:39:20,866 INFO  o.a.kafka.common.utils.AppInfoParser akka://kafka-lag-exporter/user/consumer-group-collector-kafka - Kafka version: 3.2.2
> 2022-10-05 01:39:20,866 INFO  o.a.kafka.common.utils.AppInfoParser akka://kafka-lag-exporter/user/consumer-group-collector-kafka - Kafka commitId: 38c22ad893fb6cf5
> 2022-10-05 01:39:20,866 INFO  o.a.kafka.common.utils.AppInfoParser akka://kafka-lag-exporter/user/consumer-group-collector-kafka - Kafka startTimeMs: 1664933960866
> 2022-10-05 01:39:20,867 INFO  c.l.k.ConsumerGroupCollector$ akka://kafka-lag-exporter/user/consumer-group-collector-kafka - Collecting offsets
> 2022-10-05 01:39:20,944 INFO  o.a.kafka.common.utils.AppInfoParser  - App info kafka.admin.client for adminclient-10 unregistered
> 2022-10-05 01:39:20,946 INFO  o.a.kafka.common.metrics.Metrics  - Metrics scheduler closed
> 2022-10-05 01:39:20,947 INFO  o.a.kafka.common.metrics.Metrics  - Closing reporter org.apache.kafka.common.metrics.JmxReporter
> 2022-10-05 01:39:20,947 INFO  o.a.kafka.common.metrics.Metrics  - Metrics reporters closed
> 2022-10-05 01:39:20,947 INFO  o.a.k.c.c.i.ConsumerCoordinator  - [Consumer clientId=consumer-kafkalagexporter-10, groupId=kafkalagexporter] Resetting generation and member id due to: consumer pro-actively leaving the group
> 2022-10-05 01:39:20,948 INFO  o.a.k.c.c.i.ConsumerCoordinator  - [Consumer clientId=consumer-kafkalagexporter-10, groupId=kafkalagexporter] Request joining group due to: consumer pro-actively leaving the group
> 2022-10-05 01:39:20,948 INFO  o.a.kafka.common.metrics.Metrics  - Metrics scheduler closed
> 2022-10-05 01:39:20,948 INFO  o.a.kafka.common.metrics.Metrics  - Closing reporter org.apache.kafka.common.metrics.JmxReporter
> 2022-10-05 01:39:20,948 INFO  o.a.kafka.common.metrics.Metrics  - Metrics reporters closed
> 2022-10-05 01:39:20,949 INFO  o.a.kafka.common.utils.AppInfoParser  - App info kafka.consumer for consumer-kafkalagexporter-10 unregistered
> 2022-10-05 01:39:20,950 INFO  c.l.k.ConsumerGroupCollector$ akka://kafka-lag-exporter/user/consumer-group-collector-kafka - Clearing all metrics before shutdown
> 2022-10-05 01:39:20,950 ERROR c.l.k.ConsumerGroupCollector$ akka://kafka-lag-exporter/user/consumer-group-collector-kafka - Supervisor RestartSupervisor saw failure [10]: A failure occurred while retrieving offsets.  Shutting down. java.lang.Exception: A failure occurred while retrieving offsets.  Shutting down.
> 	at com.lightbend.kafkalagexporter.ConsumerGroupCollector$CollectorBehavior.$anonfun$collector$1(ConsumerGroupCollector.scala:302)
> 	at akka.actor.typed.internal.BehaviorImpl$ReceiveBehavior.receive(BehaviorImpl.scala:136)
> 	at akka.actor.typed.Behavior$.interpret(Behavior.scala:274)
> 	at akka.actor.typed.Behavior$.interpretMessage(Behavior.scala:230)
> 	at akka.actor.typed.internal.InterceptorImpl$$anon$2.apply(InterceptorImpl.scala:57)
> 	at akka.actor.typed.internal.RestartSupervisor.aroundReceive(Supervision.scala:279)
> 	at akka.actor.typed.internal.InterceptorImpl.receive(InterceptorImpl.scala:85)
> 	at akka.actor.typed.Behavior$.interpret(Behavior.scala:274)
> 	at akka.actor.typed.Behavior$.interpretMessage(Behavior.scala:230)
> 	at akka.actor.typed.internal.adapter.ActorAdapter.handleMessage(ActorAdapter.scala:131)
> 	at akka.actor.typed.internal.adapter.ActorAdapter.aroundReceive(ActorAdapter.scala:107)
> 	at akka.actor.ActorCell.receiveMessage(ActorCell.scala:579)
> 	at akka.actor.ActorCell.invoke(ActorCell.scala:547)
> 	at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:270)
> 	at akka.dispatch.Mailbox.run(Mailbox.scala:231)
> 	at akka.dispatch.Mailbox.exec(Mailbox.scala:243)
> 	at java.base/java.util.concurrent.ForkJoinTask.doExec(Unknown Source)
> 	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Unknown Source)
> 	at java.base/java.util.concurrent.ForkJoinPool.scan(Unknown Source)
> 	at java.base/java.util.concurrent.ForkJoinPool.runWorker(Unknown Source)
> 	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(Unknown Source)
> Caused by: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.TimeoutException: Exceeded maxRetries after 1 tries.
> 	at java.base/java.util.concurrent.CompletableFuture.reportGet(Unknown Source)
> 	at java.base/java.util.concurrent.CompletableFuture.get(Unknown Source)
> 	at org.apache.kafka.common.internals.KafkaFutureImpl.get(KafkaFutureImpl.java:180)
> 	at com.lightbend.kafkalagexporter.KafkaClient$.$anonfun$kafkaFuture$1(KafkaClient.scala:85)
> 	at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
> 	at scala.util.Success.$anonfun$map$1(Try.scala:255)
> 	at scala.util.Success.map(Try.scala:213)
> 	at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
> 	at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
> 	at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
> 	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
> 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
> 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
> 	at java.base/java.lang.Thread.run(Unknown Source)
> Caused by: org.apache.kafka.common.errors.TimeoutException: Exceeded maxRetries after 1 tries.
> 

After some investigation, I found the number of retries is hardcoded to 0.
This PR allow the user to change that value and with that, I was able to make the exporter work again.