### PR TITLE
Implement Openshift best practice with regard to the root group

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,18 +95,18 @@ lazy val kafkaLagExporter =
         val layerCopy = layerIdsAscending.map { layerId =>
           val files = dockerBaseDirectory.split(UnixSeparatorChar)(1)
           val path = layerId.map(i => s"$i/$files").getOrElse(s"$files")
-          Cmd("COPY", "--chown=1001:1001", s"$path /$files")
+          Cmd("COPY", "--chown=1001:0", s"$path /$files")
         }
         Seq(
           Cmd("FROM", "eclipse-temurin:17-jre-alpine"),
           Cmd("RUN", "apk add --no-cache bash"),
-          Cmd("RUN", "addgroup -S -g 1001 kafkalagexporter; adduser -S -u 1001 -G kafkalagexporter kafkalagexporter"),
+          Cmd("RUN", "adduser -S -u 1001 kafkalagexporter"),
           Cmd("WORKDIR", "/opt/docker"),
           Cmd("USER", "1001"),
           Cmd("LABEL", labels)
         ) ++
         layerCopy ++
-        dockerExposedPorts.value.map(p => Cmd("EXPOSE", p.toString)) ++ 
+        dockerExposedPorts.value.map(p => Cmd("EXPOSE", p.toString)) ++
         Seq(
           ExecCmd(
             "CMD",

--- a/build.sbt
+++ b/build.sbt
@@ -108,6 +108,7 @@ lazy val kafkaLagExporter =
         layerCopy ++
         dockerExposedPorts.value.map(p => Cmd("EXPOSE", p.toString)) ++
         Seq(
+          Cmd("RUN chgrp -R 0 /opt/docker && chmod -R g=u /opt/docker"),
           ExecCmd(
             "CMD",
             "/opt/docker/bin/kafka-lag-exporter",


### PR DESCRIPTION
After we upgraded OpenShift, kafka-lag-exporter will no longer start:

```text
exec /opt/docker/bin/kafka-lag-exporter: permission denied
```

This is because the random-id user does not have execute permission to the executable. 

It appears from [a comment in build.sbt](https://github.com/seglo/kafka-lag-exporter/blob/master/build.sbt#L68) that the intention is to follow OpenShift best practices, but the linked document states that files and directories should be accessible to the root group, in the same way that they are accessible to the owner. This is because the random-id user that runs the container will always be part of the root group.

Instead, `build.sbt` creates a separate `kafkalagexporter` group, and assigns files and directories to that group. This PR will remove the `kafkalagexporter` group, and fix permissions as suggested in the OpenShift best practices document.
