### PR TITLE
Add quotes for lookup.redis.separator

### DIFF
--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -92,7 +92,7 @@ data:
         prefix = {{ . }}
         {{- end }}
         {{- with .separator }}
-        separator = {{ . }}
+        separator = {{ . | quote }}
         {{- end }}
         {{- with .retention }}
         retention = {{ . }}


### PR DESCRIPTION
Without the quote, the pod cannot start, as the semi column for example are not recognized as a string