### PR TITLE
(chart) Allow port name to be configured via values

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -67,7 +67,7 @@ spec:
             {{- end }}
           {{- end }}
           ports:
-            - name: http
+            - name: {{ .Values.service.portName }}
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           {{- if .Values.securityContext }}
@@ -77,7 +77,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /metrics?name[]=kafka_consumergroup_poll_time_ms
-              port: http
+              port: {{ .Values.service.portName }}
             initialDelaySeconds: {{ .Values.livenessProbeInitialDelay }}
             periodSeconds: {{ .Values.livenessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbeTimeout }}
@@ -86,7 +86,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /metrics?name[]=kafka_consumergroup_poll_time_ms
-              port: http
+              port: {{ .Values.service.portName }}
             initialDelaySeconds: {{ .Values.readinessProbeInitialDelay }}
             periodSeconds: {{ .Values.readinessProbePeriodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbeTimeout }}

--- a/charts/kafka-lag-exporter/templates/050-Service.yaml
+++ b/charts/kafka-lag-exporter/templates/050-Service.yaml
@@ -18,6 +18,6 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.port }}
       protocol: TCP
-      name: http
+      name: {{ .Values.service.portName }}
   selector:
     {{- include "kafka-lag-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/kafka-lag-exporter/values.yaml
+++ b/charts/kafka-lag-exporter/values.yaml
@@ -150,6 +150,7 @@ initContainers: []
 service:
   type: ClusterIP
   port: 8000
+  portName: http
   additionalLabels: {}
 resources: {}
   # limits:


### PR DESCRIPTION
Due to running older version of prometheus and to support multiple container sending metrics, we need port names in specific formats.