### PR TITLE
Add option to set name and bootstrap broker without quotes

### DIFF
--- a/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
+++ b/charts/kafka-lag-exporter/templates/030-ConfigMap.yaml
@@ -15,8 +15,16 @@ data:
       clusters = [
         {{- range $cluster := .Values.clusters }}
         {
+          {{- if $cluster.nameNoQuotes }}
+          name = {{ $cluster.nameNoQuotes }}
+          {{- else }}
           name = "{{ $cluster.name }}"
+          {{- end }}
+          {{- if $cluster.bootstrapBrokersNoQuotes }}
+          bootstrap-brokers = {{ $cluster.bootstrapBrokersNoQuotes }}
+          {{- else }}
           bootstrap-brokers = "{{ $cluster.bootstrapBrokers }}"
+          {{- end }}
           {{- if $cluster.groupWhitelist }}
           group-whitelist = [
             {{- $lastIndex := sub (len $cluster.groupWhitelist) 1}}


### PR DESCRIPTION
To allow using environment variables in the name since HOCON does not support substitutions in a quoted string.