### PR TITLE
Fix duplicate 'envFrom'

### DIFF
--- a/charts/kafka-lag-exporter/templates/040-Deployment.yaml
+++ b/charts/kafka-lag-exporter/templates/040-Deployment.yaml
@@ -52,15 +52,12 @@ spec:
           env:
 {{ toYaml .Values.env | indent 10 }}
           {{- end }}
-          {{- if .Values.envFromConfigMapRefs }}
+          {{- if or (.Values.envFromConfigMapRefs) (.Values.envFromSecretRefs) }}
           envFrom:
             {{- range .Values.envFromConfigMapRefs }}
             - configMapRef:
                 name: {{ . }}
             {{- end }}
-          {{- end }}
-          {{- if .Values.envFromSecretRefs }}
-          envFrom:
             {{- range .Values.envFromSecretRefs }}
             - secretRef:
                 name: {{ . }}


### PR DESCRIPTION
Fixes issue of duplicate 'envFrom' entry when using both `envFromConfigMapRefs` and `envFromSecretRefs`.