### PR TITLE
Implement connection pooling for redis lookup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,6 +77,7 @@ jobs:
   minikube-test:
     name: Integration tests using Minikube
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     strategy:
       fail-fast: false
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,7 @@ lazy val kafkaLagExporter =
           Cmd("COPY", "--chown=1001:0", s"$path /$files")
         }
         Seq(
-          Cmd("FROM", "eclipse-temurin:17-jre-alpine"),
+          Cmd("FROM", "--platform=linux/amd64", "eclipse-temurin:17-jre-alpine"),
           Cmd("RUN", "apk add --no-cache bash"),
           Cmd("RUN", "adduser -S -u 1001 kafkalagexporter"),
           Cmd("WORKDIR", "/opt/docker"),

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,57 +1,80 @@
 # kafka-lag-exporter local test cluster
-# See dockerhub for different versions of kafka and zookeeper
-# https://hub.docker.com/r/wurstmeister/kafka/
-# https://hub.docker.com/r/wurstmeister/zookeeper/
-version: '2'
+version: "3"
 services:
   redis:
-    image: redis:6.2.6
+    image: bitnami/redis:latest
     ports:
       - "6379:6379"
-  zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
-    ports:
-      - "2181:2181"
-  kafka:
-    image: wurstmeister/kafka:2.12-2.2.0
-    ports:
-      - "9094:9094"
-      - "1099:1099"
     environment:
-      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
-      PORT_COMMAND: "docker port `hostname` 9094 | cut -d: -f 2"
-      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://_{HOSTNAME_COMMAND}:_{PORT_COMMAND}
-      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_JMX_OPTS: "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.rmi.port=1099"
-      JMX_PORT: 1099
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-  kafka-producer-perf-test:
-    image: wurstmeister/kafka:2.12-2.2.0
-    command: >
-      bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-producer-perf-test.sh --topic replicated-topic --num-records 10000000 --record-size 10 --throughput 1000 --producer-props bootstrap.servers=kafka:9092"
+      - ALLOW_EMPTY_PASSWORD=yes
+  zookeeper1:
+    image: bitnami/zookeeper:latest
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  zookeeper2:
+    image: bitnami/zookeeper:latest
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka1:
+    image: bitnami/kafka:latest
+    ports:
+      - '9093:9093'
+    environment:
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka1:9092,EXTERNAL://localhost:9093
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper1:2181
+      - KAFKA_DEFAULT_REPLICATION_FACTOR=1
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    depends_on:
+      - zookeeper1
+  kafka2:
+    image: bitnami/kafka:latest
+    ports:
+      - '9193:9193'
+    environment:
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka2:9192,EXTERNAL://localhost:9193
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_CFG_LISTENERS=CLIENT://:9192,EXTERNAL://:9193
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper2:2181
+      - KAFKA_DEFAULT_REPLICATION_FACTOR=1
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+    depends_on:
+      - zookeeper2
+  kafka1-producer:
+    image: bitnami/kafka:latest
+    command: kafka-producer-perf-test.sh --topic test --num-records 10000000 --record-size 10 --throughput 10 --producer-props bootstrap.servers=kafka1:9092
+    depends_on:
+      - kafka1
+  kafka2-producer:
+    image: bitnami/kafka:latest
+    command: kafka-producer-perf-test.sh --topic test --num-records 10000000 --record-size 10 --throughput 20 --producer-props bootstrap.servers=kafka2:9092
+    depends_on:
+      - kafka2
   # each kafka-consumer-test has its own consumer.id so it can be differentiated by consumer group information easily.
-  consumer-group1-consumer1:
-    image: wurstmeister/kafka:2.12-2.2.0
-    command: >
-      bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-1 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9092 > /dev/null"
-  consumer-group1-consumer2:
-    image: wurstmeister/kafka:2.12-2.2.0
-    command: >
-      bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-2 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9092 > /dev/null"
-  consumer-group1-consumer3:
-    image: wurstmeister/kafka:2.12-2.2.0
-    command: >
-      bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-3 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9092 > /dev/null"
-  consumer-group2-consumer1:
-    image: wurstmeister/kafka:2.12-2.2.0
-    command: >
-      bash -c "until kafka-topics.sh --zookeeper zookeeper:2181 --create --topic replicated-topic --partitions 3 --replication-factor 1 --if-not-exists; do echo \"Waiting for Kafka to be ready..\"; done
-      && kafka-console-consumer.sh --consumer-property group.id=test-consumer-group-two --consumer-property client.id=test-client-two-id-1 --consumer-property enable.auto.commit=true --topic replicated-topic --bootstrap-server kafka:9092 > /dev/null"
+  kafka1-group1-consumer1:
+    image: bitnami/kafka:latest
+    command: kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-1 --consumer-property enable.auto.commit=true --topic test --bootstrap-server kafka1:9092
+    depends_on:
+      - kafka1-producer
+  kafka1-group1-consumer2:
+    image: bitnami/kafka:latest
+    command: kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-2 --consumer-property enable.auto.commit=true --topic test --bootstrap-server kafka1:9092
+    depends_on:
+      - kafka1-producer
+  kafka1-group2-consumer1:
+    image: bitnami/kafka:latest
+    command: kafka-console-consumer.sh --consumer-property group.id=test-consumer-group-two --consumer-property client.id=test-client-two-id-1 --consumer-property enable.auto.commit=true --topic test --bootstrap-server kafka1:9092
+    depends_on:
+      - kafka1-producer
+  kafka2-group1-consumer1:
+    image: bitnami/kafka:latest
+    command: kafka-console-consumer.sh --consumer-property group.id=test-consumer-group --consumer-property client.id=test-client-id-1 --consumer-property enable.auto.commit=true --topic test --bootstrap-server kafka2:9192
+    depends_on:
+      - kafka2-producer

--- a/examples/k8s/strimzi-kafka-cluster.yaml
+++ b/examples/k8s/strimzi-kafka-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: strimzi-kafka-cluster
 spec:
   kafka:
-    version: 3.2.0
+    version: 3.4.0
     replicas: 1
     listeners:
       - name: plain

--- a/src/main/scala/com/lightbend/kafkalagexporter/LookupTableConfig.scala
+++ b/src/main/scala/com/lightbend/kafkalagexporter/LookupTableConfig.scala
@@ -5,7 +5,7 @@
 
 package com.lightbend.kafkalagexporter
 
-import com.redis.RedisClient
+import com.redis.RedisClientPool
 import com.typesafe.config.Config
 
 import scala.compat.java8.DurationConverters.DurationOps
@@ -31,8 +31,8 @@ object LookupTableConfig {
   final class MemoryTableConfig(config: Config) extends LookupTableConfig {
     import MemoryTableConfig._
 
-    val table = config.getConfig("lookup-table.memory")
-    val size =
+    val table: Config = config.getConfig("lookup-table.memory")
+    val size: Int =
       if (table.hasPath("size")) table.getInt("size")
       else SizeDefault
 
@@ -52,60 +52,83 @@ object LookupTableConfig {
     val SeparatorDefault: String = ":"
     val RetentionDefault: Duration = 1.day
     val ExpirationDefault: Duration = 1.day
+    val MaxIdleDefault: Int = 1
+    val MaxConnectionsDefault: Int = RedisClientPool.UNLIMITED_CONNECTIONS
+    val PoolWaitTimeoutDefault: Long = 3000L
   }
 
   final class RedisTableConfig(config: Config) extends LookupTableConfig {
     import RedisTableConfig._
 
-    val redis = config.getConfig("lookup-table.redis")
-    val database =
+    val redis: Config = config.getConfig("lookup-table.redis")
+    val database: Int =
       if (redis.hasPath("database"))
         redis.getInt("database")
       else DatabaseDefault
 
-    val host =
+    val host: String =
       if (redis.hasPath("host"))
         redis.getString("host")
       else HostDefault
 
-    val port =
+    val port: Int =
       if (redis.hasPath("port"))
         redis.getInt("port")
       else PortDefault
 
-    val timeout =
+    val timeout: Duration =
       if (redis.hasPath("timeout"))
         redis.getDuration("timeout").toScala
       else TimeoutDefault
 
-    val prefix =
+    val prefix: String =
       if (redis.hasPath("prefix"))
         redis.getString("prefix")
       else PrefixDefault
 
-    val separator =
+    val separator: String =
       if (redis.hasPath("separator"))
         redis.getString("separator")
       else SeparatorDefault
 
-    val retention =
+    val retention: Duration =
       if (redis.hasPath("retention"))
         redis.getDuration("retention").toScala
       else RetentionDefault
 
-    val expiration =
+    val expiration: Duration =
       if (redis.hasPath("expiration"))
         redis.getDuration("expiration").toScala
       else ExpirationDefault
 
-    val client = new RedisClient(
-      database = database,
+    val maxIdle: Int =
+      if (redis.hasPath("maxIdle"))
+        redis.getInt("maxIdle")
+      else MaxIdleDefault
+
+    val maxConnections: Int =
+      if (redis.hasPath("maxConnections"))
+        redis.getInt("maxConnections")
+      else MaxConnectionsDefault
+
+    val poolWaitTimeout: Long =
+      if (redis.hasPath("poolWaitTimeout"))
+        redis.getLong("poolWaitTimeout")
+      else PoolWaitTimeoutDefault
+
+    val clients = new RedisClientPool(
       host = host,
       port = port,
-      timeout = timeout.toSeconds.toInt
+      maxIdle = maxIdle,
+      database = database,
+      timeout = timeout.toSeconds.toInt,
+      maxConnections = maxConnections,
+      poolWaitTimeout = poolWaitTimeout
     )
 
-    override def close(): Unit = client.close()
+    override def close(): Unit = {
+      clients.close()
+    }
 
     override def toString: String = {
       s"""Redis Lookup Table:
@@ -117,6 +140,9 @@ object LookupTableConfig {
          |  Separator: $separator
          |  Retention: $retention
          |  Expiration: $expiration
+         |  MaxIdle: $maxIdle
+         |  MaxConnections: $maxConnections
+         |  PoolWaitTimeout: $poolWaitTimeout
      """.stripMargin
     }
   }

--- a/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
+++ b/src/test/scala/com/lightbend/kafkalagexporter/LookupTableSpec.scala
@@ -77,8 +77,8 @@ class LookupTableSpec
 
   override def beforeEach(): Unit = {
     // make sure the Point table is empty
-    redisClients.withClient {
-      redisClient => {
+    redisClients.withClient { redisClient =>
+      {
         redisClient.del(table.key)
       }
     }


### PR DESCRIPTION
The Redis Lookup table implementation was not thread safe, so the exporter is failing when having more than one cluster.

This PR implement the redis connection pool, following documentation from `debasishg/scala-redis`: https://github.com/debasishg/scala-redis#using-client-pooling

Docker image built from that PR is available here: https://hub.docker.com/layers/guillaumeroland/kafka-lag-exporter/0.8.3-SNAPSHOT/images/sha256-856f2aeee34270d3f0793157e9fff196f397ee91c3ad8f3de5573e5590102c69?context=explore

I also made some changes in the docker-compose.yml file to make local development easier, as previous images were not compatible with Apple ARM-based CPUs.