### PR TITLE
Cg empty member topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ target
 *.iml
 application.conf
 !examples/standalone/application.conf
+.bloop
+.metals
+.vscode
+project


### PR DESCRIPTION
This PR enables to collect metrics for topics with no active members for a consumer group that consumes from multiple topics.
Fixes https://github.com/seglo/kafka-lag-exporter/issues/290 